### PR TITLE
Added a CloseSession method

### DIFF
--- a/abstraction.go
+++ b/abstraction.go
@@ -212,3 +212,12 @@ func (d *Abstraction) signalsHandler() {
 		}
 	}
 }
+
+// CloseSession method stops the goroutine running the signalsHandler function, and deletes internal data
+func (d *Abstraction) CloseSession() {
+	for k, v := range d.Sigmap {
+		delete(d.Sigmap, k)
+		close(v)
+	}
+	d.Conn.RemoveSignal(d.Recv)
+}

--- a/abstraction.go
+++ b/abstraction.go
@@ -28,6 +28,17 @@ type AbsSignal struct {
 	Signame string
 }
 
+type IAbstraction interface {
+	GetConn() *dbus.Conn
+	InitSession(SessionType, string) error
+	GetSignal(string) ([]interface{}, error)
+	GetChannel(string) chan *AbsSignal
+	ExportMethods(interface{}, dbus.ObjectPath, string)
+	CallMethod(dbus.ObjectPath, string, string, string, ...interface{}) *dbus.Call
+	ListenSignalFromSender(string, string, string, string)
+	CloseSession()
+}
+
 //Abstraction type contains the necessary vars and is used as receiver of our methods
 type Abstraction struct {
 	Conn       *dbus.Conn


### PR DESCRIPTION
CloseSession method stops the goroutine running the signalsHandler function, and deletes internal data